### PR TITLE
gitiles: update to version 1.6.0.20250324.

### DIFF
--- a/Formula/gitiles.rb
+++ b/Formula/gitiles.rb
@@ -3,27 +3,39 @@ class Gitiles < Formula
   homepage "https://gerrit.googlesource.com/gitiles"
   url "https://gerrit.googlesource.com/gitiles",
       using:    :git,
-      revision: "84fb315541de4364c63a55bda7b96a1a44e0637a"
-  version "1.4.0.20240607"
+      revision: "06b65fdf46c7bae589e11151ca834e8bd8319e86"
+  version "1.6.0.20250324"
   license "Apache-2.0"
 
   head "https://gerrit.googlesource.com/gitiles",
        using:  :git,
        branch: "master"
 
-  depends_on "bazel" => :build
-  depends_on :macos # TODO: fix bazel build failure on linux
-  depends_on "openjdk@11"
+  depends_on "bazel@7" => :build
+  depends_on "openjdk@21"
 
   def install
-    # Force Gitiles to use openjdk@11
-    ENV["JAVA_HOME"] = Language::Java.java_home("11")
-    ENV["EXTRA_BAZEL_ARGS"] = "--host_javabase=@local_jdk//:jdk"
+    # Force Bazel to use brew OpenJDK
+    java_version = "21"
+    java_home_env = Language::Java.java_home_env(java_version)
+    ENV.merge! java_home_env.transform_keys(&:to_s)
+    extra_bazel_args = ["--tool_java_runtime_version=local_jdk"]
+    # Bazel clears environment variables which breaks superenv shims
+    ENV.remove "PATH", Superenv.shims_path
+
+    # Fix linking on Linux
+    if OS.linux? && build.bottle? && ENV["HOMEBREW_DYNAMIC_LINKER"]
+      # set dynamic linker similar to cc shim so that bottle works on older Linux
+      extra_bazel_args << "--linkopt=-Wl,--dynamic-linker=#{ENV["HOMEBREW_DYNAMIC_LINKER"]}"
+    end
+
+    # Construct Bazel arguments
+    ENV["EXTRA_BAZEL_ARGS"] = extra_bazel_args.join(" ")
     # Force Bazel ./compile.sh to put its temporary files in the buildpath
     ENV["BAZEL_WRKDIR"] = buildpath/"work"
 
     # Allow Gitiles to use current version of bazel
-    (buildpath / ".bazelversion").atomic_write Formula["bazel"].version.to_s
+    (buildpath / ".bazelversion").atomic_write Formula["bazel@7"].version.to_s
     # Remove bazel cache options
     inreplace Dir["**/.bazelrc"] do |f|
       f.gsub! "build --repository_cache=~/.gerritcodereview/bazel-cache/repository", ""


### PR DESCRIPTION
gitiles: update to version 1.6.0.20250324.

Also:
- keep bazel at bazel@7
- switch from openjdk@11 to openjdk@21
- update bazel args for linux
